### PR TITLE
fix: AI units can be auto-sold after dying #120

### DIFF
--- a/source/game_management/movemaker.py
+++ b/source/game_management/movemaker.py
@@ -504,7 +504,7 @@ class MoveMaker:
                 min_pow_health = pow_health, unit
             self.move_unit(player, unit, all_units, all_players, all_setls, quads, cfg)
             overall_wealth -= unit.plan.cost / 10
-        if player.wealth + overall_wealth < 0:
+        if (player.wealth + overall_wealth < 0) and min_pow_health[1] in player.units:
             player.wealth += min_pow_health[1].plan.cost
             player.units.remove(min_pow_health[1])
 

--- a/source/tests/test_movemaker.py
+++ b/source/tests/test_movemaker.py
@@ -931,6 +931,24 @@ class MovemakerTest(unittest.TestCase):
         self.assertEqual(self.TEST_UNIT.plan.cost, self.TEST_PLAYER.wealth)
         self.assertFalse(self.TEST_PLAYER.units)
 
+    @patch("source.game_management.movemaker.investigate_relic", lambda *args: None)
+    def test_make_move_negative_wealth_doesnt_remove_already_removed_units(self):
+        """
+        Ensure that when an AI player would have negative wealth at the end of their turn, the unit will die in
+        movement, so we cannot sell on negative wealth after unit dies.
+        """
+        # By making the test player defensive, we guarantee that the reason for attack is the other unit's faction.
+        self.TEST_PLAYER.ai_playstyle.attacking = AttackPlaystyle.DEFENSIVE
+        self.TEST_PLAYER.units[0] = self.TEST_UNIT_2
+        wealth_before_combat = self.TEST_PLAYER.wealth
+        infidel_player = Player("Inf", Faction.INFIDELS, 0, 0, [], [self.TEST_UNIT_3], [], set(), set())
+
+        self.movemaker.make_move(self.TEST_PLAYER, [self.TEST_PLAYER, infidel_player], self.QUADS, self.TEST_CONFIG,
+                                 False)
+
+        self.assertEqual(wealth_before_combat, self.TEST_PLAYER.wealth)
+        self.assertFalse(self.TEST_PLAYER.units)
+
     def test_move_settler_unit_not_far_enough(self):
         """
         Ensure that when a settler unit has not moved far enough away from its original settlement, it does not found a


### PR DESCRIPTION
Hello, I put a test reproducing the problem `ValueError: list.remove(x): x not in list
` on wealth check based on other attack test. So we will not find this bug again 👍🏻.