### PR TITLE
ci: add Node.js 22 setup to fix deprecated Node.js 20 warning

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -9,6 +9,10 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
@@ -61,6 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora
     steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
     steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}


### PR DESCRIPTION
## Summary

Adds `actions/setup-node@v4` with `node-version: '22'` to all workflow jobs to fix the Node.js 20 deprecation warning.

## Problem

GitHub Actions runners now default to Node.js 24, but `actions/checkout@v4` and `actions/setup-python@v5` target Node.js 20, producing this warning:

```
Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24:
  actions/checkout@v4, actions/setup-python@v5
```

## Solution

Explicitly set Node.js to v22 in all 4 workflow jobs (ci, publish, bundle, bundle-fedora) using `actions/setup-node@v4`. This follows the [recommended approach](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Changes

- **ci.yml**: Added setup-node step to validate job
- **publish.yml**: Added setup-node step to publish job
- **bundle.yml**: Added setup-node steps to both bundle and bundle-fedora jobs

No functional change to build output or runtime behavior.

Fixes #189